### PR TITLE
Fix up RAID and BIOS to use the newly-added provisioner finder code in the deployer. [2/2]

### DIFF
--- a/chef/cookbooks/bios/providers/update.rb
+++ b/chef/cookbooks/bios/providers/update.rb
@@ -112,6 +112,8 @@ end
 def wsman_update(product)
   require 'wsman'
   # Get bmc parameters
+  provisioner_server = (node[:crowbar_wall][:provisioner_server] rescue nil)
+  return false unless provisioner_server
   ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "bmc").address
   user = node["ipmi"]["bmc_user"] rescue "crowbar"
   password = node["ipmi"]["bmc_password"] rescue "crowbar"
@@ -119,7 +121,7 @@ def wsman_update(product)
            :host => ip, :port => 443, 
            :debug_time => false }
 
-  system("wget -q #{@@provisioner_server}/files/wsman/supported.json -O /tmp/supported.json")
+  system("wget -q #{provisioner_server}/files/wsman/supported.json -O /tmp/supported.json")
   jsondata = ::File.read('/tmp/supported.json')
   data = JSON.parse(jsondata)
   unless data
@@ -212,7 +214,7 @@ def wsman_update(product)
     file = d[1]
 
     Chef::Log.info "Update: #{id} #{file}"
-    answer, jid = wsman_update.update(id, "#{@@provisioner_server}/files/#{file}")
+    answer, jid = wsman_update.update(id, "#{provisioner_server}/files/#{file}")
     if answer
       Chef::Log.info "WSMAN scheduled: #{id} with #{file}"
       reboot = true if jid # Reboot if we need to.

--- a/chef/cookbooks/bios/recipes/bios-install.rb
+++ b/chef/cookbooks/bios/recipes/bios-install.rb
@@ -2,7 +2,8 @@
 
 include_recipe "bios::bios-common"
 
-return unless @@provisioner_server
+provisioner_server = (node[:crowbar_wall][:provisioner_server] rescue nil)
+return unless provisioner_server
 
 include_recipe "bios::bios-tools"
 
@@ -18,7 +19,7 @@ product.strip!
     end
   end
   remote_file "/tmp/#{f}" do
-    source "#{@@provisioner_server}/files/dell_bios/#{f}"
+    source "#{provisioner_server}/files/dell_bios/#{f}"
     mode '0755'
     action :create_if_missing
   end

--- a/chef/cookbooks/bios/recipes/bios-tools.rb
+++ b/chef/cookbooks/bios/recipes/bios-tools.rb
@@ -8,6 +8,8 @@
 
 include_recipe "bios::bios-common"
 
+provisioner_server = (node[:crowbar_wall][:provisioner_server] rescue nil)
+return unless provisioner_server
 bmc="bmc-2012-10-17.tgz"
 setupbios="setupbios-2012-10-10.tgz"
 socflash="socflash_v10601.zip"
@@ -24,7 +26,7 @@ socflash="socflash_v10601.zip"
 # These are tools that we rely on to configure PEC gear.
 [bmc,setupbios,socflash].each do |f|
   a = remote_file "/tmp/#{f}" do
-    source "#{@@provisioner_server}/files/dell_bios/tools/#{f}"
+    source "#{provisioner_server}/files/dell_bios/tools/#{f}"
     action :nothing
   end
   a.run_action(:create_if_missing)


### PR DESCRIPTION
As the title says.

 chef/cookbooks/bios/providers/update.rb     |    6 ++++--
 chef/cookbooks/bios/recipes/bios-install.rb |    5 +++--
 chef/cookbooks/bios/recipes/bios-tools.rb   |    4 +++-
 3 files changed, 10 insertions(+), 5 deletions(-)

Crowbar-Pull-ID: f87cf3eb20a70a1b2238be9809fdb482ca63d3be

Crowbar-Release: development
