### PR TITLE
use http instead of ftp sites [1/1]

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ bc_build() {
     mkdir -p "$BC_CACHE/files/wsman"
 
     cd "$BC_CACHE/files/wsman"
-    curl -s ftp://ftp.us.dell.com/catalog/Catalog.cab > Catalog.cab
+    curl -s http://ftp.us.dell.com/catalog/Catalog.cab > Catalog.cab
     cabextract Catalog.cab
     rm -rf Catalog.cab
     [[ ! -f Catalog.xml ]] && die "Can't find Catalog.xml"


### PR DESCRIPTION
use http instead of ftp sites for curl pulls as dell-firewall blocks ftp traffic

 build.sh |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 22ca997310a3b44efff1035ee9cc2e237084b035

Crowbar-Release: development
