### PR TITLE
Cleanup of errors related to ipmi_si [2/2]

### DIFF
--- a/chef/data_bags/crowbar-data/bios-set-PowerEdgeR610-Storage.json
+++ b/chef/data_bags/crowbar-data/bios-set-PowerEdgeR610-Storage.json
@@ -10,13 +10,6 @@
           "DefaultValue": "",
           "attr_name": "ProcVirtualization",
           "GroupID": null
-        },
-        "BootMode": {
-          "GroupID": "BootSettings",
-          "value": "Uefi",
-          "DefaultValue": null,
-          "instance_id": "BIOS.Setup.1-1:BootMode",
-          "attr_name": "BootMode"
         }
       }
     }

--- a/chef/data_bags/crowbar-data/bios-set-PowerEdgeR610-Virtualization.json
+++ b/chef/data_bags/crowbar-data/bios-set-PowerEdgeR610-Virtualization.json
@@ -24,13 +24,6 @@
           "DefaultValue": "",
           "attr_name": "ProcVirtualization",
           "GroupID": null
-        },
-       "BootMode": {
-          "GroupID": "BootSettings",
-          "value": "Uefi",
-          "DefaultValue": null,
-          "instance_id": "BIOS.Setup.1-1:BootMode",
-          "attr_name": "BootMode"
         }
       }
     }

--- a/chef/data_bags/crowbar-data/bios-set-PowerEdgeR710-Storage.json
+++ b/chef/data_bags/crowbar-data/bios-set-PowerEdgeR710-Storage.json
@@ -10,13 +10,6 @@
           "DefaultValue": "",
           "attr_name": "ProcVirtualization",
           "GroupID": null
-        },
-        "BootMode": {
-          "GroupID": "BootSettings",
-          "value": "Uefi",
-          "DefaultValue": null,
-          "instance_id": "BIOS.Setup.1-1:BootMode",
-          "attr_name": "BootMode"
         }
       }
     }

--- a/chef/data_bags/crowbar-data/bios-set-PowerEdgeR710-Virtualization.json
+++ b/chef/data_bags/crowbar-data/bios-set-PowerEdgeR710-Virtualization.json
@@ -24,13 +24,6 @@
           "DefaultValue": "",
           "attr_name": "ProcVirtualization",
           "GroupID": null
-        },
-        "BootMode": {
-          "GroupID": "BootSettings",
-          "value": "Uefi",
-          "DefaultValue": null,
-          "instance_id": "BIOS.Setup.1-1:BootMode",
-          "attr_name": "BootMode"
         }
       }
     }

--- a/updates/unbmc.sh
+++ b/updates/unbmc.sh
@@ -37,7 +37,7 @@ fi
 
 if [[ $1 = ubuntu-12.04 ]]; then
     rmmod ipmi_si
+    rmmod ipmi_msghandler
 fi
 rmmod ipmi_devintf
-rmmod ipmi_msghandler
 

--- a/updates/unbmc.sh
+++ b/updates/unbmc.sh
@@ -1,18 +1,4 @@
 #!/bin/bash
-# Copyright (c) 2013 Dell Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 
 timed() {
     local deadline=$(($(date '+%s') + 60))
@@ -32,12 +18,26 @@ timed() {
     )
 }
 
-timed modprobe ipmi_si
+grep -i "vmware virtual platform\|virtualbox" /sys/class/dmi/id/product_name
+if [ $? -eq 0 ]; then
+    echo "Not flashing BMC ... unsupported platform (virtual)"
+    return 0
+fi
+
+if [[ $1 = ubuntu-12.04 ]]; then
+    timed modprobe ipmi_si
+fi
+
 timed modprobe ipmi_devintf
  
-ipmitool power status || socflash_x64 option=r of=/dev/null
+ipmitool power status 
+if [ $? -ne 0 ]; then
+    /updates/socflash_x64 option=r of=/dev/null
+fi 
 
-rmmod ipmi_si
+if [[ $1 = ubuntu-12.04 ]]; then
+    rmmod ipmi_si
+fi
 rmmod ipmi_devintf
 rmmod ipmi_msghandler
 

--- a/updates/unbmc.sh
+++ b/updates/unbmc.sh
@@ -35,9 +35,10 @@ if [ $? -ne 0 ]; then
     /updates/socflash_x64 option=r of=/dev/null
 fi 
 
+rmmod ipmi_devintf
+
 if [[ $1 = ubuntu-12.04 ]]; then
     rmmod ipmi_si
     rmmod ipmi_msghandler
 fi
-rmmod ipmi_devintf
 


### PR DESCRIPTION
Prevent running ipmi barclamp on VMs
Prevent running unbmc.sh on VMs during admin install
Fix cosmetic issues with modprobe of ipmi_si failures on centos/redhat

 .../bios-set-PowerEdgeR610-Storage.json            |    7 ----
 .../bios-set-PowerEdgeR610-Virtualization.json     |    7 ----
 .../bios-set-PowerEdgeR710-Storage.json            |    7 ----
 .../bios-set-PowerEdgeR710-Virtualization.json     |    7 ----
 updates/unbmc.sh                                   |   37 ++++++++++----------
 5 files changed, 19 insertions(+), 46 deletions(-)

Crowbar-Pull-ID: 6d14733eb8ebf8e528649f2c05512e135ae91f0b

Crowbar-Release: pebbles
