### PR TITLE
Re-add deleted license for unbmc.sh [1/1]

### DIFF
--- a/updates/unbmc.sh
+++ b/updates/unbmc.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+# Copyright (c) 2013 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 
 timed() {
     local deadline=$(($(date '+%s') + 60))


### PR DESCRIPTION
Deleted license by mistake - re-adding to file

 updates/unbmc.sh |   15 +++++++++++++++
 1 file changed, 15 insertions(+)

Crowbar-Pull-ID: 1c30e6e3425868c68daaa5d4ef55ed792df77225

Crowbar-Release: pebbles
