### PR TITLE
Adding support for R620 [2/2]

### DIFF
--- a/bin/crowbar_bios
+++ b/bin/crowbar_bios
@@ -16,6 +16,6 @@
 
 
 require File.join(File.expand_path(File.dirname(__FILE__)), "barclamp_lib")
-@barclamp = "bios"
+@barclamp = "dell_bios"
 
 main

--- a/chef/cookbooks/bios/attributes/default.rb
+++ b/chef/cookbooks/bios/attributes/default.rb
@@ -13,10 +13,10 @@
 # limitations under the License.
 #
 
-default[:bios][:config] = {}
-default[:bios][:config][:environment] = "bios-config-default"
-default[:bios][:debug] = false
-default[:bios][:bios_setup_enable] = true 
-default[:bios][:bios_update_enable] = true 
+default[:dell_bios][:config] = {}
+default[:dell_bios][:config][:environment] = "bios-config-default"
+default[:dell_bios][:debug] = false
+default[:dell_bios][:bios_setup_enable] = true 
+default[:dell_bios][:bios_update_enable] = true 
 
 default[:crowbar][:hardware][:bios_set]= "Storage"

--- a/chef/cookbooks/bios/recipes/bios-configure.rb
+++ b/chef/cookbooks/bios/recipes/bios-configure.rb
@@ -24,7 +24,7 @@ rescue
   nil
 end
 
-debug = node[:bios][:debug]
+debug = node[:dell_bios][:debug]
 product = node[:dmi][:system][:product_name].gsub(/\s+/, '')
 default_set = "bios-set-#{product}-default"
 bios_set = get_bag_item_safe(default_set, "bios defaults")

--- a/chef/data_bags/crowbar-data/bios-set-PowerEdgeR620-HadoopInfra.json
+++ b/chef/data_bags/crowbar-data/bios-set-PowerEdgeR620-HadoopInfra.json
@@ -1,0 +1,18 @@
+{
+  "id": "bios-set-PowerEdgeR620-HadoopInfra",
+  "style": "wsman",
+  "attributes": {
+    "BIOS": {
+      "default": {
+        "ProcVirtualization": {
+          "value": "Disabled",
+          "instance_id": "BIOS.Setup.1-1:ProcVirtualization",
+          "DefaultValue": "",
+          "attr_name": "ProcVirtualization",
+          "GroupID": null
+        }
+      }
+    }
+  }
+}
+

--- a/chef/data_bags/crowbar-data/bios-set-PowerEdgeR620-Storage.json
+++ b/chef/data_bags/crowbar-data/bios-set-PowerEdgeR620-Storage.json
@@ -10,13 +10,6 @@
           "DefaultValue": "",
           "attr_name": "ProcVirtualization",
           "GroupID": null
-        },
-        "BootMode": {
-          "GroupID": "BootSettings",
-          "value": "Uefi",
-          "DefaultValue": null,
-          "instance_id": "BIOS.Setup.1-1:BootMode",
-          "attr_name": "BootMode"
         }
       }
     }

--- a/chef/data_bags/crowbar-data/bios-set-PowerEdgeR620-Virtualization.json
+++ b/chef/data_bags/crowbar-data/bios-set-PowerEdgeR620-Virtualization.json
@@ -24,13 +24,6 @@
           "DefaultValue": "",
           "attr_name": "ProcVirtualization",
           "GroupID": null
-        },
-        "BootMode": {
-          "GroupID": "BootSettings",
-          "value": "Uefi",
-          "DefaultValue": null,
-          "instance_id": "BIOS.Setup.1-1:BootMode",
-          "attr_name": "BootMode"
         }
       }
     }

--- a/chef/data_bags/crowbar-data/bios-set-PowerEdgeR620-default.json
+++ b/chef/data_bags/crowbar-data/bios-set-PowerEdgeR620-default.json
@@ -1210,7 +1210,7 @@
         "AttachMode": {
           "attr_name": "AttachMode",
           "GroupID": "RFS.1",
-          "value": "Attach",
+          "value": "Auto Attach",
           "instance_id": "iDRAC.Embedded.1#RFS.1#AttachMode",
           "DefaultValue": "Auto Attach"
         },

--- a/chef/data_bags/crowbar-data/bios-set-PowerEdgeR720-HadoopInfra.json
+++ b/chef/data_bags/crowbar-data/bios-set-PowerEdgeR720-HadoopInfra.json
@@ -1,0 +1,18 @@
+{
+  "id": "bios-set-PowerEdgeR720-HadoopInfra",
+  "style": "wsman",
+  "attributes": {
+    "BIOS": {
+      "default": {
+        "ProcVirtualization": {
+          "value": "Disabled",
+          "instance_id": "BIOS.Setup.1-1:ProcVirtualization",
+          "DefaultValue": "",
+          "attr_name": "ProcVirtualization",
+          "GroupID": null
+        }
+      }
+    }
+  }
+}
+

--- a/chef/data_bags/crowbar-data/bios-set-PowerEdgeR720xd-HadoopInfra.json
+++ b/chef/data_bags/crowbar-data/bios-set-PowerEdgeR720xd-HadoopInfra.json
@@ -1,0 +1,17 @@
+{
+  "id": "bios-set-PowerEdgeR720xd-HadoopInfra",
+  "style": "wsman",
+  "attributes": {
+    "BIOS": {
+      "default": {
+        "ProcVirtualization": {
+          "value": "Disabled",
+          "instance_id": "BIOS.Setup.1-1:ProcVirtualization",
+          "DefaultValue": "",
+          "attr_name": "ProcVirtualization",
+          "GroupID": null
+        }
+      }
+    }
+  }
+}

--- a/updates/unbmc.sh
+++ b/updates/unbmc.sh
@@ -33,7 +33,7 @@ timed() {
     )
 }
 
-grep -i "vmware virtual platform\|virtualbox" /sys/class/dmi/id/product_name
+grep -i "vmware virtual platform\|virtualbox\|bochs" /sys/class/dmi/id/product_name
 if [ $? -eq 0 ]; then
     echo "Not flashing BMC ... unsupported platform (virtual)"
     return 0


### PR DESCRIPTION
Adding support for R620
    Fixing incorrect boot mode for R620 (UEFI to BIOS)
    Fixing missing data bags for R620 (Hadoop config)
    Fixing missing data bags for R720/R720xd in Roxy (related to Hadoop)
    Limiting size of created RAID volume to 2TB or less (when in BIOS boot mode)

Fix for incorrect return value in RAID driver (on creating multiple VDs)

Fix for not running unbmc.sh on kvm

 bin/crowbar_bios                                   |    2 +-
 chef/cookbooks/bios/attributes/default.rb          |   10 +++++-----
 chef/cookbooks/bios/recipes/bios-configure.rb      |    2 +-
 .../bios-set-PowerEdgeR620-HadoopInfra.json        |   18 ++++++++++++++++++
 .../bios-set-PowerEdgeR620-Storage.json            |    7 -------
 .../bios-set-PowerEdgeR620-Virtualization.json     |    7 -------
 .../bios-set-PowerEdgeR620-default.json            |    2 +-
 .../bios-set-PowerEdgeR720-HadoopInfra.json        |   18 ++++++++++++++++++
 .../bios-set-PowerEdgeR720xd-HadoopInfra.json      |   17 +++++++++++++++++
 updates/unbmc.sh                                   |    2 +-
 10 files changed, 62 insertions(+), 23 deletions(-)

Crowbar-Pull-ID: 0a2799b5e11a53fda8ff7725a72576d158abc4c3

Crowbar-Release: roxy
