### PR TITLE
Fixing broken updates in BIOS barclamp [2/2]

### DIFF
--- a/chef/cookbooks/bios/providers/update.rb
+++ b/chef/cookbooks/bios/providers/update.rb
@@ -294,8 +294,8 @@ action :update do
   # Do wsman style if enabled for it (but only it).
   # Otherwise attempt to do the types as they come in.
   #
-  wsman = node["bios"]["updaters"][product]["wsman"] rescue nil
-  update = node["bios"]["updaters"][product][type] rescue nil
+  wsman = node["dell_bios"]["updaters"][product]["wsman"] rescue nil
+  update = node["dell_bios"]["updaters"][product][type] rescue nil
   if (update and type == "wsman")
     begin
       break unless can_try_again(type,max_tries)

--- a/chef/cookbooks/bios/recipes/bios-common.rb
+++ b/chef/cookbooks/bios/recipes/bios-common.rb
@@ -22,7 +22,7 @@ node["crowbar_wall"] = {} if node["crowbar_wall"].nil?
 node["crowbar_wall"]["status"] = {} if node["crowbar_wall"]["status"].nil?
 node["crowbar_wall"]["status"]["bios"] = []
 
-@@debug = node[:bios][:debug]
+@@debug = node[:dell_bios][:debug]
 
 centos = ubuntu = false
 platform = node[:platform]
@@ -37,9 +37,9 @@ log("BIOS: running on OS:[#{platform}] on #{node[:dmi][:system][:product_name]} 
 
 
 ## enforce platfrom limitations
-@@bios_setup_enable = node[:bios][:bios_setup_enable] & centos & !@@is_admin
-@@bios_update_enable = node[:bios][:bios_update_enable] & centos & !@@is_admin
-@@bmc_update_enable = node[:bios][:bmc_update_enable] & centos & !@@is_admin
+@@bios_setup_enable = node[:dell_bios][:bios_setup_enable] & centos & !@@is_admin
+@@bios_update_enable = node[:dell_bios][:bios_update_enable] & centos & !@@is_admin
+@@bmc_update_enable = node[:dell_bios][:bmc_update_enable] & centos & !@@is_admin
 
 
 node["crowbar_wall"]["status"]["bios"] << "Bios Barclamp using centos:#{centos} ubuntu:#{ubuntu}"

--- a/chef/cookbooks/bios/recipes/bios-configure.rb
+++ b/chef/cookbooks/bios/recipes/bios-configure.rb
@@ -31,7 +31,7 @@ bios_set = get_bag_item_safe(default_set, "bios defaults")
 bios_version = node[:dmi] && node[:dmi][:bios] && node[:dmi][:bios][:version]
 style = bios_set && bios_set[:style] || "legacy"
 style = "legacy" if style.length == 0
-node[:bios][:style] = style
+node[:dell_bios][:style] = style
 Chef::Log.info("Bios set style is: #{style}")
 
 if !@@bios_setup_enable
@@ -110,7 +110,7 @@ else
     bios_configure "wsman" do
       type           "wsman"
       product         node[:dmi][:system][:product_name]
-      max_tries       node[:bios][:max_tries]
+      max_tries       node[:dell_bios][:max_tries]
       values          values
       problem_file "/var/log/chef/hw-problem.log"
       action   :configure

--- a/chef/cookbooks/bios/recipes/bios-install.rb
+++ b/chef/cookbooks/bios/recipes/bios-install.rb
@@ -19,12 +19,16 @@ provisioner_server = (node[:crowbar_wall][:provisioner_server] rescue nil)
 if (provisioner_server == nil)
   provisioners = search(:node, "roles:provisioner-server")
   provisioner = provisioners[0] if provisioners
-  web_port = provisioner["provisioner"]["web_port"]
-  address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(provisioner, "admin").address
-  provisioner_server = "#{address}:#{web_port}"
-  log("Provisioner server info is #{provisioner_server}")
-  node[:crowbar_wall][:provisioner_server] = provisioner_server
-  node.save 
+  if (provisioner != nil)
+    web_port = provisioner["provisioner"]["web_port"]
+    address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(provisioner, "admin").address
+    provisioner_server = "#{address}:#{web_port}"
+    log("Provisioner server info is #{provisioner_server}")
+    node[:crowbar_wall][:provisioner_server] = provisioner_server
+    node.save 
+  else
+    log("Provisioner server info could not be retrieved")
+  end
 end
 return unless provisioner_server
 

--- a/chef/cookbooks/bios/recipes/bios-install.rb
+++ b/chef/cookbooks/bios/recipes/bios-install.rb
@@ -42,7 +42,7 @@ bios_update "bmc" do
   type            "bmc"
   problem_file    problem_file
   product         product
-  max_tries       node[:bios][:max_tries]
+  max_tries       node[:dell_bios][:max_tries]
   only_if         { @@bmc_update_enable }
   action   :update
 end
@@ -52,7 +52,7 @@ bios_update "bios" do
   type            "bios"
   problem_file    problem_file
   product         product
-  max_tries       node[:bios][:max_tries]
+  max_tries       node[:dell_bios][:max_tries]
   only_if         { @@bios_update_enable }
   action   :update
 end
@@ -61,7 +61,7 @@ bios_update "wsman" do
   type           "wsman"
   problem_file    problem_file
   product         product
-  max_tries       node[:bios][:max_tries]
+  max_tries       node[:dell_bios][:max_tries]
   only_if         { @@bios_update_enable }
   action   :update
 end

--- a/chef/cookbooks/bios/recipes/bios-install.rb
+++ b/chef/cookbooks/bios/recipes/bios-install.rb
@@ -38,8 +38,8 @@ problem_file = "/var/log/chef/hw-problem.log"
 product = node[:dmi][:system][:product_name]
 product.strip!
 %w{bios bmc}.each do |t|
-  next unless (node["bios"]["updaters"][product][t] rescue nil)
-  f = node["bios"]["updaters"][product][t]
+  next unless (node["dell_bios"]["updaters"][product][t] rescue nil)
+  f = node["dell_bios"]["updaters"][product][t]
   if f.include?('/')
     directory "/tmp/#{f.split('/')[0..-2].join('/')}" do
       recursive true

--- a/chef/cookbooks/bios/recipes/bios-install.rb
+++ b/chef/cookbooks/bios/recipes/bios-install.rb
@@ -16,6 +16,16 @@
 include_recipe "bios::bios-common"
 
 provisioner_server = (node[:crowbar_wall][:provisioner_server] rescue nil)
+if (provisioner_server == nil)
+  provisioners = search(:node, "roles:provisioner-server")
+  provisioner = provisioners[0] if provisioners
+  web_port = provisioner["provisioner"]["web_port"]
+  address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(provisioner, "admin").address
+  provisioner_server = "#{address}:#{web_port}"
+  log("Provisioner server info is #{provisioner_server}")
+  node[:crowbar_wall][:provisioner_server] = provisioner_server
+  node.save 
+end
 return unless provisioner_server
 
 include_recipe "bios::bios-tools"

--- a/chef/cookbooks/bios/recipes/bios-tools.rb
+++ b/chef/cookbooks/bios/recipes/bios-tools.rb
@@ -37,7 +37,7 @@ socflash="socflash_v10601.zip"
 # These are tools that we rely on to configure PEC gear.
 [bmc,setupbios,socflash].each do |f|
   a = remote_file "/tmp/#{f}" do
-    source "#{provisioner_server}/files/dell_bios/tools/#{f}"
+    source "http://#{provisioner_server}/files/dell_bios/tools/#{f}"
     action :nothing
   end
   a.run_action(:create_if_missing)

--- a/chef/data_bags/crowbar/bc-template-dell_bios.json
+++ b/chef/data_bags/crowbar/bc-template-dell_bios.json
@@ -2,7 +2,7 @@
   "id": "bc-template-dell_bios",
   "description": "manages bios configuration for Dell PEC hardware",
   "attributes": {
-    "bios": {
+    "dell_bios": {
           "bios_setup_enable" : true,
           "bmc_update_enable": true,
           "bios_update_enable": true,

--- a/chef/data_bags/crowbar/bc-template-dell_bios.schema
+++ b/chef/data_bags/crowbar/bc-template-dell_bios.schema
@@ -3,7 +3,7 @@
     "id": { "type": "str", "required": true, "pattern": "/^bc-dell_bios-|^bc-template-dell_bios$/" },
     "description": { "type": "str", "required": true },
     "attributes": { "type": "map", "required": true, "mapping": {
-        "bios": { "type": "map", "required": true, "mapping": {
+        "dell_bios": { "type": "map", "required": true, "mapping": {
             "bios_setup_enable" : { "type": "bool", "required": true},
 	    "bios_update_enable" : { "type": "bool", "required": true},
 	    "bmc_update_enable" : { "type": "bool", "required": true},


### PR DESCRIPTION
Fixes following items
    Updates broken in BIOS barclamp because provisioner server ip was not set on node
    Updates broken in BIOS barclamp because crowbar.yml changed to dell_bios from bios
        Code depending on node["bios"] was broken as a result
    Making dell_raid barclamp user manageable (visible and editable in UI)
    Removing debug messages in raid barclamp

Fixing inability to edit dell_bios barclamp (crash and show purple bunny) 

 chef/cookbooks/bios/providers/update.rb            |    4 ++--
 chef/cookbooks/bios/recipes/bios-common.rb         |    8 +++----
 chef/cookbooks/bios/recipes/bios-configure.rb      |    4 ++--
 chef/cookbooks/bios/recipes/bios-install.rb        |   24 ++++++++++++++++----
 chef/cookbooks/bios/recipes/bios-tools.rb          |    2 +-
 chef/data_bags/crowbar/bc-template-dell_bios.json  |    2 +-
 .../data_bags/crowbar/bc-template-dell_bios.schema |    2 +-
 7 files changed, 30 insertions(+), 16 deletions(-)

Crowbar-Pull-ID: fb47f88dd5ff32aa605d25a7371c60927a2b573a

Crowbar-Release: roxy
