### PR TITLE
Resolving incorrect attribute display when editing the bios barclamp [1/1]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -31,7 +31,7 @@ crowbar:
 locale_additions:
   en:
     barclamp:
-      bios:
+      dell_bios:
         edit_deployment: 
           deployment: Deployment
         edit_attributes:


### PR DESCRIPTION
Changes to crowbar.yml to change name to dell_bios - Fixes attribute display

 crowbar.yml |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 599b0a48074e2d4a649d06346c6c8ac310dd1f0f

Crowbar-Release: roxy
