### PR TITLE
Change default SysProfile value to PerfOptimized in hadoop builds for R720xd [1/1]

### DIFF
--- a/chef/data_bags/crowbar-data/bios-set-PowerEdgeR720xd-Hadoop.json
+++ b/chef/data_bags/crowbar-data/bios-set-PowerEdgeR720xd-Hadoop.json
@@ -10,6 +10,13 @@
           "DefaultValue": "",
           "attr_name": "ProcVirtualization",
           "GroupID": null
+        },
+        "SysProfile": {
+          "GroupID": "SysProfileSettings",
+          "value": "PerfOptimized",
+          "DefaultValue": null,
+          "instance_id": "BIOS.Setup.1-1:SysProfile",
+          "attr_name": "SysProfile"
         }
       }
     }

--- a/chef/data_bags/crowbar-data/bios-set-PowerEdgeR720xd-HadoopInfra.json
+++ b/chef/data_bags/crowbar-data/bios-set-PowerEdgeR720xd-HadoopInfra.json
@@ -10,6 +10,13 @@
           "DefaultValue": "",
           "attr_name": "ProcVirtualization",
           "GroupID": null
+        },
+        "SysProfile": {
+          "GroupID": "SysProfileSettings",
+          "value": "PerfOptimized",
+          "DefaultValue": null,
+          "instance_id": "BIOS.Setup.1-1:SysProfile",
+          "attr_name": "SysProfile"
         }
       }
     }


### PR DESCRIPTION
Change default SysProfile value to PerfOptimized in hadoop builds for R720xd. 
This address CES-1087. 

 .../bios-set-PowerEdgeR720xd-Hadoop.json           |    7 +++++++
 .../bios-set-PowerEdgeR720xd-HadoopInfra.json      |    7 +++++++
 2 files changed, 14 insertions(+)

Crowbar-Pull-ID: 00531a7c7fc1c89f2e6a3585053c69210ab1c712

Crowbar-Release: roxy
