### PR TITLE
Fixing incorrect data bags for R720 and R720xd [1/1]

### DIFF
--- a/chef/data_bags/crowbar-data/bios-set-PowerEdgeR720-Hadoop.json
+++ b/chef/data_bags/crowbar-data/bios-set-PowerEdgeR720-Hadoop.json
@@ -10,6 +10,13 @@
           "DefaultValue": "",
           "attr_name": "ProcVirtualization",
           "GroupID": null
+        },
+        "BootMode": {
+          "GroupID": "BootSettings",
+          "value": "Uefi",
+          "DefaultValue": null,
+          "instance_id": "BIOS.Setup.1-1:BootMode",
+          "attr_name": "BootMode"
         }
       }
     }

--- a/chef/data_bags/crowbar-data/bios-set-PowerEdgeR720-HadoopInfra.json
+++ b/chef/data_bags/crowbar-data/bios-set-PowerEdgeR720-HadoopInfra.json
@@ -10,6 +10,13 @@
           "DefaultValue": "",
           "attr_name": "ProcVirtualization",
           "GroupID": null
+        },
+        "BootMode": {
+          "GroupID": "BootSettings",
+          "value": "Uefi",
+          "DefaultValue": null,
+          "instance_id": "BIOS.Setup.1-1:BootMode",
+          "attr_name": "BootMode"
         }
       }
     }

--- a/chef/data_bags/crowbar-data/bios-set-PowerEdgeR720xd-Hadoop.json
+++ b/chef/data_bags/crowbar-data/bios-set-PowerEdgeR720xd-Hadoop.json
@@ -17,6 +17,13 @@
           "DefaultValue": null,
           "instance_id": "BIOS.Setup.1-1:SysProfile",
           "attr_name": "SysProfile"
+        },
+        "BootMode": {
+          "GroupID": "BootSettings",
+          "value": "Uefi",
+          "DefaultValue": null,
+          "instance_id": "BIOS.Setup.1-1:BootMode",
+          "attr_name": "BootMode"
         }
       }
     }

--- a/chef/data_bags/crowbar-data/bios-set-PowerEdgeR720xd-HadoopInfra.json
+++ b/chef/data_bags/crowbar-data/bios-set-PowerEdgeR720xd-HadoopInfra.json
@@ -17,6 +17,13 @@
           "DefaultValue": null,
           "instance_id": "BIOS.Setup.1-1:SysProfile",
           "attr_name": "SysProfile"
+        },
+        "BootMode": {
+          "GroupID": "BootSettings",
+          "value": "Uefi",
+          "DefaultValue": null,
+          "instance_id": "BIOS.Setup.1-1:BootMode",
+          "attr_name": "BootMode"
         }
       }
     }


### PR DESCRIPTION
Setting boot mode to UEFI from BIOS

 .../bios-set-PowerEdgeR720-Hadoop.json             |    7 +++++++
 .../bios-set-PowerEdgeR720-HadoopInfra.json        |    7 +++++++
 .../bios-set-PowerEdgeR720xd-Hadoop.json           |    7 +++++++
 .../bios-set-PowerEdgeR720xd-HadoopInfra.json      |    7 +++++++
 4 files changed, 28 insertions(+)

Crowbar-Pull-ID: ff1f14dce087d8f4276bcfd9e1f3034f81bb1300

Crowbar-Release: hadoop-2.4
