### PR TITLE
Fix for CES 1400 - failure to set BIOS attributes [1/1]

### DIFF
--- a/chef/cookbooks/bios/libraries/wsman_attributes.rb
+++ b/chef/cookbooks/bios/libraries/wsman_attributes.rb
@@ -245,7 +245,11 @@ class WSMANAttributes
     attrs << h
     h = self.attributes("DCIM_NICAttribute")
     attrs << h
-    h = self.attributes("DCIM_iDRACCardAttribute")
+    h = self.attributes("DCIM_iDRACCardString")
+    attrs << h
+    h = self.attributes("DCIM_iDRACCardInteger")
+    attrs << h
+    h = self.attributes("DCIM_iDRACCardEnumeration")
     attrs << h
     h = self.attributes("DCIM_RAIDAttribute")
     attrs << h


### PR DESCRIPTION
Enumerating idrac attributes via the sub classes

 chef/cookbooks/bios/libraries/wsman_attributes.rb |    6 +++++-
 1 file changed, 5 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 2fec7064a72e347fd9b1294d10796b77db483ce8

Crowbar-Release: hadoop-2.4
