### PR TITLE
Fixes for CES 1499 [1/2]

### DIFF
--- a/chef/cookbooks/bios/libraries/wsman_attributes.rb
+++ b/chef/cookbooks/bios/libraries/wsman_attributes.rb
@@ -356,7 +356,12 @@ class WSMANAttributes
     ## boot sources if the bios attributes set the pending mode to UEFI ##
     ## The config job is created by the calling method..                ##
     if (class_name == "DCIM_BIOSService")
-      return_val, reboot = @wsman.check_and_handle_boot_sources()
+      rebootFlag = false
+      return_val, rebootFlag = @wsman.check_and_handle_boot_sources()
+      #override what the method returned...basically nothing may have happened
+      # in the check and handle boot sources method...but we still need to reboot
+      # to set the attributes
+      reboot = true if (!reboot and rebootFlag)  
     end
     ## End boot manipulation hack
 


### PR DESCRIPTION
Fixed enabling transition of boot mode when there are no boot sources to be
enabled or re-ordered

Fixed parsing of job information after creating targeted config job in set-boot
recipe

Polling job for completion before passing on to bios recipes to ensure reboot

 chef/cookbooks/bios/libraries/wsman_attributes.rb |    7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 9dddf1b9efb69db3a1c15a80d4749bd036bb6328

Crowbar-Release: hadoop-2.4
