### PR TITLE
Add applied attribute

### DIFF
--- a/chef/data_bags/crowbar/bc-template-dell_bios.json
+++ b/chef/data_bags/crowbar/bc-template-dell_bios.json
@@ -54,6 +54,7 @@
   "deployment": {
     "dell_bios": {
       "crowbar-revision": 0,
+      "crowbar-applied": false,
       "element_states": {
         "dell_bios": [ "update", "hardware-installing", "hardware-updating" ],
         "dell_bios_tools": [ "discovering" ]

--- a/chef/data_bags/crowbar/bc-template-dell_bios.schema
+++ b/chef/data_bags/crowbar/bc-template-dell_bios.schema
@@ -23,6 +23,7 @@
         "dell_bios": { "type": "map", "required": true, "mapping": {
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
+            "crowbar-applied": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
             "element_states": { "type": "map", "mapping": {
                 = : { "type": "seq", "required": true,

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -28,6 +28,7 @@ crowbar:
   order: 17
   chef_order: 17
   run_order: 17
+  proposal_schema_version: 3
 
 build_cmd: build.sh
 


### PR DESCRIPTION
We add a crowbar applied attribute to mark the proposal as applied after the chef run. This allows the UI to show that the current form of the proposal has been 'applied' successfully (i.e. chef-client completed the run w/ success) and that the proposal was then not modified.

The second patch adds the proposal_schema_revision, so we can add the attribute to schema for ('3rd party') barclamps that currently do not have it. The crowbar.yml was missing it previously, I'm not sure if this is intentional or not.

Refs: https://github.com/crowbar/crowbar/pull/2044 (which adds this attribute to barclamps which lack it), https://github.com/crowbar/barclamp-crowbar/pull/1068 (which marks the proposals as applied) and https://bugzilla.novell.com/show_bug.cgi?id=877486
